### PR TITLE
Be explicit about start delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ will throw an exception.
 
 * `delay` {Number} an optional delay in ms before first invocation. if no delay
 is provided, first invocation is synchronous (no setImmediate, no setTimeout).
+Note that `0` is explicitly a valid value, and will be passed to setTimeout.
 
 __Returns__: {undefined} returns nothing
 
@@ -103,8 +104,7 @@ The subscribed function will receive an error as it's only parameter.
 Add unit tests for any new or changed functionality. Ensure that lint and style
 checks pass.
 
-To start contributing, install the git prep
-ush hooks:
+To start contributing, install the git prepush hooks:
 
 ```sh
 make githooks

--- a/lib/index.js
+++ b/lib/index.js
@@ -172,7 +172,7 @@ Reissue.prototype._done = function _done(err) {
  */
 Reissue.prototype.start = function start(delay) {
     var self = this;
-    var delayMs = parseInt(delay) || 0;
+    assert.optionalNumber(delay);
 
     // before starting, see if reissue is already active. if so, throw an
     // error.
@@ -183,10 +183,10 @@ Reissue.prototype.start = function start(delay) {
     // set the flag and off we go!
     self._active = true;
 
-    if (delayMs > 0) {
+    if (typeof delay === 'number') {
         setTimeout(function _nextInvocation() {
             self._execute();
-        }, delayMs);
+        }, delay);
     } else {
         self._execute();
     }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "nsp": "^2.2.0"
   },
   "dependencies": {
-    "assert-plus": "^0.2.0"
+    "assert-plus": "^1.0.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -282,4 +282,22 @@ describe('Reissue module', function() {
         });
         timer.start(150);
     });
+
+    it('should start asynchronously after explicit 0 delay', function(done) {
+
+        var async = false;
+
+        var timer = reissue.create({
+            func: function(callback) {
+
+                // if async === false, this was called synchronously
+                assert.equal(async, true);
+                callback();
+                return done();
+            },
+            interval: 100
+        });
+        timer.start(0);
+        async = true;
+    });
 });


### PR DESCRIPTION
This modifies the behavior of `start` so that if the number zero is passed, it still uses `setTimeout` and starts the handler asynchronously. This matches what the documentation implies. The documentation has been updated to explicitly state that fact as well, and a test has been added for correctness.
