### PR TITLE
fix bound functions not applying partial args

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ __Returns__: {undefined} returns nothing
 
 The handler object also emits the following events:
 
-### handler.on('error', function(err) {...}
+### handler.on('error', function(err) {...})
 
 If your function returns an error to the callback, this event will be emitted.
 The subscribed function will receive an error as it's only parameter.

--- a/lib/bind.js
+++ b/lib/bind.js
@@ -19,7 +19,16 @@ function bind(fn, context, args) {
     assert.optionalArray(args, 'args');
 
     return function boundFn() {
-        fn.apply(context || null, args || []);
+
+        // working with arguments is a bit hazardous in terms of deopt.
+        // https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#3-managing-arguments
+        var partialArgs = new Array(arguments.length);
+
+        for (var i = 0; i < partialArgs.length; i++) {
+            partialArgs[i] = arguments[i];
+        }
+
+        fn.apply(context || null, (args || []).concat(partialArgs));
     };
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,8 @@ function Reissue(opts) {
     /**
      * the interval to execute at. if user passed in static value, wrap it in
      * a function to normalize the dynamic interval scenario.
-     * @type {Number}
+     * @type {Number | Function}
+     * @return {Number}
      */
     self._interval = (typeofInterval === 'number') ?
                         function _returnInterval() {


### PR DESCRIPTION
@yunong can you take a look? Not sure how this slipped through the cracks, even the tests were broken to begin with. Ugh. :(  

This was causing the 'error' event to not emit correctly even when an error was being passed to the provided callback.
