### PR TITLE
emit stop event. make stop faster by cancelling queued invocations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,12 @@ __Returns__: {undefined} returns nothing
 The handler object also emits the following events:
 
 ### handler.on('error', function(err) {...})
-
 If your function returns an error to the callback, this event will be emitted.
 The subscribed function will receive an error as it's only parameter.
+
+### handler.on('stop', function() {...})
+The stop event is emitted when reissue successfully completes any ongoing
+function invocations and stops all future invocations.
 
 
 ## Contributing

--- a/lib/index.js
+++ b/lib/index.js
@@ -99,6 +99,15 @@ function Reissue(opts) {
      * @type {Function}
      */
     self._nextHandlerId = null;
+
+    /**
+     * boolean flag set when we are waiting for user supplied function to
+     * complete. technically we should know this if self._nextHandlerId had
+     * a flag to show whether or not it had already been executed, but this is
+     * a safer way to do it.
+     * @type {Boolean}
+     */
+    self._inUserFunc = false;
 }
 util.inherits(Reissue, events.EventEmitter);
 
@@ -220,7 +229,7 @@ Reissue.prototype.start = function start(delay) {
     self._active = true;
 
     if (typeof delay === 'number') {
-        setTimeout(function _nextInvocation() {
+        self._nextHandlerId = setTimeout(function _nextInvocation() {
             self._execute();
         }, delay);
     } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,6 +93,12 @@ function Reissue(opts) {
      * @type {Number}
      */
     self._startTime = 0;
+
+    /**
+     * setTimeout handler of next invocation
+     * @type {Function}
+     */
+    self._nextHandlerId = null;
 }
 util.inherits(Reissue, events.EventEmitter);
 
@@ -115,6 +121,9 @@ Reissue.prototype._execute = function _execute() {
     // this last invocation might have been scheduled before user called
     // stop(). ensure we're still active before invocation.
     if (self._active === true) {
+        // set flag so we know we're currently in user supplied func
+        self._inUserFunc = true;
+        // execute their func
         self._func.apply(self._funcContext, self._funcArgs);
     }
 };
@@ -135,6 +144,11 @@ Reissue.prototype._done = function _done(err) {
     var interval = self._interval();
     var elapsedTime = Date.now() - self._startTime;
 
+    // we're out of user supplied func now
+    self._inUserFunc = false;
+    // clear out the handler id
+    self._nextHandlerId = null;
+
     // re-emit error
     if (err) {
         self.emit('error', err);
@@ -143,20 +157,40 @@ Reissue.prototype._done = function _done(err) {
     // if user called stop(), we're done! don't queue up another invocation.
     if (self._active === false) {
         return;
+    } else {
+        // start invocation immediately if: the elapsedTime is greater than the
+        // interval, which means the last execution took longer than the
+        // interval itself.  otherwise, subtract the time the previous
+        // invocation took.
+        var timeToInvocation = (elapsedTime >= interval) ?
+                                0 : (interval - elapsedTime);
+
+        self._nextHandlerId = setTimeout(function _nextInvocation() {
+            self._execute();
+        }, timeToInvocation);
+    }
+};
+
+
+
+/**
+* internal implementation of stop. clears all timeout handlers and emits the
+* stop event.
+* @private
+* @method _stop
+* @returns {undefined}
+*/
+Reissue.prototype._stop = function _stop() {
+
+    var self = this;
+
+    // clear the next invocation if one exists
+    if (self._nextHandlerId) {
+        clearTimeout(self._nextHandlerId);
+        self._nextHandlerId = null;
     }
 
-    // start invocation immediately if: the elapsedTime is greater than the
-    // interval, which means the last execution took longer than the interval
-    // itself.  otherwise, subtract the time the previous invocation took.
-    var timeToInvocation = (elapsedTime >= interval) ?
-                                0 :
-                                (interval - elapsedTime);
-
-    // assign the handler to ensure that consumers can't call start() again
-    // while we're waiting for the next invocation.
-    setTimeout(function _nextInvocation() {
-        self._execute();
-    }, timeToInvocation);
+    self.emit('stop');
 };
 
 
@@ -203,7 +237,31 @@ Reissue.prototype.start = function start(delay) {
  */
 Reissue.prototype.stop = function stop() {
     var self = this;
-    self._active = false;
+
+    // NOTE: while the below if statements could be collapsed to be more more
+    // terse, this logic is easier to read in terms of maintainability.
+
+    // check if we are currently active. if not, we can stop now.
+    if (self._active === false) {
+        self._stop();
+    } else {
+        // in the else case, we are still active. there are two possibilities
+        // here, we are either:
+        // 1) queued up waiting for the next invocation
+        // 2) waiting for user supplied function to complete
+
+        if (self._inUserFunc === false) {
+            // case #1
+            // if we're just waiting for the next invocation, call stop now
+            // which will clear out the next invocation.
+            self._stop();
+        } else {
+            // case #2
+            // set active flag to false, when we come back from user function
+            // we will check this flag and call internal _stop()
+            self._active = false;
+        }
+    }
 };
 
 


### PR DESCRIPTION
Previously, when `stop()` was called, and we weren't in the user supplied function, it would wait until right before next invocation to check before we stop.

Now, when stop is called, we check to see if we are in user supplied function, and if not, we simply clear the next scheduled invocation and stop immediately.

We also now emit a `stop` event on completion.