### PR TITLE
Timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - "0.12"
     - "4"
     - "6"
+    - "node"
 after_success: 'make report-coverage'

--- a/README.md
+++ b/README.md
@@ -101,14 +101,16 @@ If your function returns an error to the callback, this event will be emitted.
 The subscribed function will receive an error as it's only parameter.
 
 ### handler.on('stop', function() {...})
-When the `stop()` method is called, this event is emitted when when either the
+When the `stop()` method is called, this event is emitted when either the
 current invocation is successfully completed, or when the next scheduled
 invocation is successfully cancelled. If the current invocation is "stuck" in
 the sense that the callback never returns, the stop event will never fire.
 
 ### handler.on('timeout', function() {...})
 If a `timeout` value is specified, this event will be fired when any given
-invocation of the function exceeds the specified value.
+invocation of the function exceeds the specified value. However, if your user
+supplied function is synchronous, and never gives up the event loop, it is
+possible that this event may never get fired.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -59,8 +59,11 @@ reissue takes the following options to its `create()` method:
 
 * `opts.func` {Function} the function to execute. This function is invoked with
 a callback function as it's last parameter.
-* `opts.interval` {Number | Function} the inteval in ms to execute the function,
-or a function that returns an interval, allowing usage of a dynamic interval.
+* `opts.interval` {Number | Function} the interval in ms to execute the
+function, or a function that returns an interval, allowing usage of a dynamic
+interval.
+* `[opts.timeout]` {Number} an optional timeout in ms. if any invocation of the
+the supplied func exceeds this timeout, the `timeout` event is fired.
 * `[opts.context]` {Context} an optional `this` context for the function. use
 this in lieu of native `bind()` if you are concerned about performance. reissue
 uses `apply()` under the hood to do context/arg binding.
@@ -98,8 +101,14 @@ If your function returns an error to the callback, this event will be emitted.
 The subscribed function will receive an error as it's only parameter.
 
 ### handler.on('stop', function() {...})
-The stop event is emitted when reissue successfully completes any ongoing
-function invocations and stops all future invocations.
+When the `stop()` method is called, this event is emitted when when either the
+current invocation is successfully completed, or when the next scheduled
+invocation is successfully cancelled. If the current invocation is "stuck" in
+the sense that the callback never returns, the stop event will never fire.
+
+### handler.on('timeout', function() {...})
+If a `timeout` value is specified, this event will be fired when any given
+invocation of the function exceeds the specified value.
 
 
 ## Contributing
@@ -127,6 +136,6 @@ make codestyle-fix
 
 ## License
 
-Copyright (c) 2015 Alex Liu
+Copyright (c) 2017 Alex Liu
 
 Licensed under the MIT license.

--- a/lib/index.js
+++ b/lib/index.js
@@ -140,33 +140,25 @@ util.inherits(Reissue, events.EventEmitter);
 Reissue.prototype._execute = function _execute() {
 
     var self = this;
+
+    // start invocation timer
     self._startTime = Date.now();
+    // set flag so we know we're currently in user supplied func
+    self._inUserFunc = true;
+    // execute their func
+    self._func.apply(self._funcContext, self._funcArgs);
 
-    if (self._active === true) {
-        // set flag so we know we're currently in user supplied func
-        self._inUserFunc = true;
-        // execute their func
-        self._func.apply(self._funcContext, self._funcArgs);
-
-        // if timeout option is specified, schedule one here. basically, we
-        // execute the next invocation immediately above, then schedule a
-        // timeout handler, so we basically have two set timeout functions
-        // being scheduled.
-        if (self._timeoutMs !== null) {
-            // assign timeout to self so that we can cancel it if we complete
-            // on time.
-            self._timeoutHandlerId = setTimeout(
-                bind(self._onTimeout, self),
-                self._timeoutMs
-            );
-            // set our own stateful flags on timeout handler
-            self._timeoutHandlerId.___reissue = {
-                fired: false,
-                done: false
-            };
-        }
-    } else {
-        self._stop();
+    // if timeout option is specified, schedule one here. basically, we
+    // execute the next invocation immediately above, then schedule a
+    // timeout handler, so we basically have two set timeout functions
+    // being scheduled.
+    if (self._timeoutMs !== null) {
+        // assign timeout to self so that we can cancel it if we complete
+        // on time.
+        self._timeoutHandlerId = setTimeout(
+            bind(self._onTimeout, self),
+            self._timeoutMs
+        );
     }
 };
 
@@ -196,16 +188,6 @@ Reissue.prototype._done = function _done(err) {
         self.emit('error', err);
     }
 
-    // if a timeout was setup, and user supplied fn exceeded that timeout and
-    // we're still waiting for it to complete, block.
-    if (self._timeoutHandlerId) {
-        if (self._timeoutHandlerId.___reissue.fired === true &&
-        self._timeoutHandlerId.___reissue.done === false) {
-            return self.once('_timeoutComplete', function() {
-                _internalDone();
-            });
-        }
-    }
     // in every other case, we're fine, since we've finished before the
     // timeout event has occurred. call _internalDone where we will clear
     // the timeout event.
@@ -286,31 +268,9 @@ Reissue.prototype._onTimeout = function _onTimeout() {
         return;
     }
 
-    self._timeoutHandlerId.___reissue.fired = true;
-
-    function _internalOnTimeoutDone() {
-        self._timeoutHandlerId.___reissue.done = true;
-        self.emit('_timeoutComplete');
-    }
-
     // if user is listening to timeout event, fire the event and block on its
     // completion.
-    if (self.listenerCount('timeout') > 0) {
-        self.emit('timeout',  function onTimeoutHandlerComplete(cancel) {
-            _internalOnTimeoutDone();
-
-            // if cancel is true, clear the currently timed out invocation,
-            // schedule another one immediately.
-            if (cancel === true) {
-                clearTimeout(self._nextHandlerId);
-                self._execute();
-            }
-        });
-    }
-    // otherwise, we're done
-    else {
-        _internalOnTimeoutDone();
-    }
+    self.emit('timeout');
 };
 
 //------------------------------------------------------------------------------

--- a/lib/index.js
+++ b/lib/index.js
@@ -257,6 +257,12 @@ Reissue.prototype._stop = function _stop() {
         self._nextHandlerId = null;
     }
 
+    // clear any timeouts scheduled
+    if (self._timeoutHandlerId) {
+        clearTimeout(self._timeoutHandlerId);
+        self._timeoutHandlerId = null;
+    }
+
     self.emit('stop');
 };
 
@@ -320,8 +326,11 @@ Reissue.prototype._onTimeout = function _onTimeout() {
  * @return {undefined}
  */
 Reissue.prototype.start = function start(delay) {
-    var self = this;
+
     assert.optionalNumber(delay);
+
+    var self = this;
+    var realDelay = (typeof delay === 'number' && delay >= 0) ? delay : 0;
 
     // before starting, see if reissue is already active. if so, throw an
     // error.
@@ -332,15 +341,9 @@ Reissue.prototype.start = function start(delay) {
     // set the flag and off we go!
     self._active = true;
 
-    if (typeof delay === 'number') {
-        self._nextHandlerId = setTimeout(function _nextInvocation() {
-            self._execute();
-        }, delay);
-    } else {
-        self._nextHandlerId = setImmediate(function() {
-            self._execute();
-        });
-    }
+    self._nextHandlerId = setTimeout(function _nextInvocation() {
+        self._execute();
+    }, realDelay);
 };
 
 
@@ -351,6 +354,7 @@ Reissue.prototype.start = function start(delay) {
  * @return {undefined}
  */
 Reissue.prototype.stop = function stop() {
+
     var self = this;
 
     // NOTE: while the below if statements could be collapsed to be more more
@@ -364,7 +368,6 @@ Reissue.prototype.stop = function stop() {
         // here, we are either:
         // 1) queued up waiting for the next invocation
         // 2) waiting for user supplied function to complete
-
         if (self._inUserFunc === false) {
             // case #1
             // if we're just waiting for the next invocation, call stop now

--- a/lib/index.js
+++ b/lib/index.js
@@ -148,8 +148,12 @@ Reissue.prototype._execute = function _execute() {
     self._startTime = Date.now();
     // set flag so we know we're currently in user supplied func
     self._inUserFunc = true;
-    // execute their func
-    self._func.apply(self._funcContext, self._funcArgs);
+    // execute their func on a setImmediate, such that we can schedule the
+    // timeout first. to be clear though, user func could be sync and our
+    // timeout may never fire.
+    setImmediate(function _executeImmediately() {
+        self._func.apply(self._funcContext, self._funcArgs);
+    });
 
     // if timeout option is specified, schedule one here. basically, we
     // execute the next invocation immediately above, then schedule a

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,12 +102,6 @@ function Reissue(opts) {
     self._startTime = 0;
 
     /**
-     * setTimeout handler of next invocation
-     * @type {Function}
-     */
-    self._nextHandlerId = null;
-
-    /**
      * boolean flag set when we are waiting for user supplied function to
      * complete. technically we should know this if self._nextHandlerId had
      * a flag to show whether or not it had already been executed, but this is
@@ -115,6 +109,12 @@ function Reissue(opts) {
      * @type {Boolean}
      */
     self._inUserFunc = false;
+
+    /**
+     * setTimeout handler of next invocation
+     * @type {Function}
+     */
+    self._nextHandlerId = null;
 
     /*
      * setTimeout handler of an internal timeout implementation. used to fire

--- a/lib/index.js
+++ b/lib/index.js
@@ -239,12 +239,10 @@ Reissue.prototype._stop = function _stop() {
         self._nextHandlerId = null;
     }
 
-    // clear any timeouts scheduled
-    if (self._timeoutHandlerId) {
-        clearTimeout(self._timeoutHandlerId);
-        self._timeoutHandlerId = null;
-    }
+    //  no need to clear timeout handlers, as they're already cleared
+    //  in _done before we get here.
 
+    // emit stop, and we're done!
     self.emit('stop');
 };
 
@@ -262,15 +260,11 @@ Reissue.prototype._onTimeout = function _onTimeout() {
 
     var self = this;
 
-    // before we do anything, see if we got stopped.
-    if (self._active === false) {
-        self._stop();
-        return;
+    // we might have called stop during current invocation. emit timeout event
+    // only if we're still active.
+    if (self._active === true) {
+        self.emit('timeout');
     }
-
-    // if user is listening to timeout event, fire the event and block on its
-    // completion.
-    self.emit('timeout');
 };
 
 //------------------------------------------------------------------------------

--- a/lib/index.js
+++ b/lib/index.js
@@ -138,11 +138,10 @@ util.inherits(Reissue, events.EventEmitter);
  * @return {undefined}
  */
 Reissue.prototype._execute = function _execute() {
+
     var self = this;
     self._startTime = Date.now();
 
-    // this last invocation might have been scheduled before user called
-    // stop(). ensure we're still active before invocation.
     if (self._active === true) {
         // set flag so we know we're currently in user supplied func
         self._inUserFunc = true;
@@ -166,6 +165,8 @@ Reissue.prototype._execute = function _execute() {
                 done: false
             };
         }
+    } else {
+        self._stop();
     }
 };
 
@@ -273,6 +274,12 @@ Reissue.prototype._onTimeout = function _onTimeout() {
 
     var self = this;
 
+    // before we do anything, see if we got stopped.
+    if (self._active === false) {
+        self._stop();
+        return;
+    }
+
     self._timeoutHandlerId.___reissue.fired = true;
 
     function _internalOnTimeoutDone() {
@@ -283,8 +290,15 @@ Reissue.prototype._onTimeout = function _onTimeout() {
     // if user is listening to timeout event, fire the event and block on its
     // completion.
     if (self.listenerCount('timeout') > 0) {
-        self.emit('timeout',  function onTimeoutHandlerComplete() {
+        self.emit('timeout',  function onTimeoutHandlerComplete(cancel) {
             _internalOnTimeoutDone();
+
+            // if cancel is true, clear the currently timed out invocation,
+            // schedule another one immediately.
+            if (cancel === true) {
+                clearTimeout(self._nextHandlerId);
+                self._execute();
+            }
         });
     }
     // otherwise, we're done
@@ -323,7 +337,9 @@ Reissue.prototype.start = function start(delay) {
             self._execute();
         }, delay);
     } else {
-        self._execute();
+        self._nextHandlerId = setImmediate(function() {
+            self._execute();
+        });
     }
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,9 @@ var bind = require('./bind');
  * @param {Object} opts.func an the function to execute
  * @param {Object | Function} opts.interval the interval to execute at, or a
  * function that returns an interval. function allows for dynamic intervals.
+ * @param {Number} [opts.timeout] an optional timeout value that causes the
+ * `timeout` event to be fired when a given invocation exceeds this value.
+ * function that returns an interval. function allows for dynamic intervals.
  * @param {Object} [opts.context] the context to bind the function to
  * @param {Object} [opts.args] any arguments to pass to the function
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,7 @@ function Reissue(opts) {
     assert.func(opts.func, 'func');
     assert.optionalObject(opts.context, 'context');
     assert.optionalArray(opts.args, 'args');
+    assert.optionalNumber(opts.timeout, 'timeout');
 
     // assert options of different types
     var typeofInterval = typeof opts.interval;
@@ -76,6 +77,12 @@ function Reissue(opts) {
     self._funcArgs = (opts.args) ?
                         opts.args.concat(boundDone) : [boundDone];
 
+    /**
+     * schedule an optional timeout which will trigger timeout event if a
+     * given invocation exceeds this number.
+     * @type {Number}
+     */
+    self._timeoutMs = opts.timeout || null;
 
     //--------------------------------------------------------------------------
     // internal properties
@@ -108,6 +115,13 @@ function Reissue(opts) {
      * @type {Boolean}
      */
     self._inUserFunc = false;
+
+    /*
+     * setTimeout handler of an internal timeout implementation. used to fire
+     * the timeout event if a user supplied function takes too long.
+     * @type {Function}
+     */
+    self._timeoutHandlerId = null;
 }
 util.inherits(Reissue, events.EventEmitter);
 
@@ -134,6 +148,24 @@ Reissue.prototype._execute = function _execute() {
         self._inUserFunc = true;
         // execute their func
         self._func.apply(self._funcContext, self._funcArgs);
+
+        // if timeout option is specified, schedule one here. basically, we
+        // execute the next invocation immediately above, then schedule a
+        // timeout handler, so we basically have two set timeout functions
+        // being scheduled.
+        if (self._timeoutMs !== null) {
+            // assign timeout to self so that we can cancel it if we complete
+            // on time.
+            self._timeoutHandlerId = setTimeout(
+                bind(self._onTimeout, self),
+                self._timeoutMs
+            );
+            // set our own stateful flags on timeout handler
+            self._timeoutHandlerId.___reissue = {
+                fired: false,
+                done: false
+            };
+        }
     }
 };
 
@@ -163,23 +195,48 @@ Reissue.prototype._done = function _done(err) {
         self.emit('error', err);
     }
 
-    // if user called stop(), we're done! don't queue up another invocation.
-    if (self._active === false) {
-        return;
-    } else {
-        // start invocation immediately if: the elapsedTime is greater than the
-        // interval, which means the last execution took longer than the
-        // interval itself.  otherwise, subtract the time the previous
-        // invocation took.
-        var timeToInvocation = (elapsedTime >= interval) ?
-                                0 : (interval - elapsedTime);
+    // if a timeout was setup, and user supplied fn exceeded that timeout and
+    // we're still waiting for it to complete, block.
+    if (self._timeoutHandlerId) {
+        if (self._timeoutHandlerId.___reissue.fired === true &&
+        self._timeoutHandlerId.___reissue.done === false) {
+            return self.once('_timeoutComplete', function() {
+                _internalDone();
+            });
+        }
+    }
+    // in every other case, we're fine, since we've finished before the
+    // timeout event has occurred. call _internalDone where we will clear
+    // the timeout event.
+    return _internalDone();
 
-        self._nextHandlerId = setTimeout(function _nextInvocation() {
-            self._execute();
-        }, timeToInvocation);
+    // common completion function called by forked code above
+    function _internalDone() {
+
+        // clear any timeout handlers
+        if (self._timeoutHandlerId) {
+            clearTimeout(self._timeoutHandlerId);
+            self._timeoutHandlerId = null;
+        }
+
+        // if user called stop() sometime during last invocation, we're done!
+        // don't queue up another invocation.
+        if (self._active === false) {
+            self._stop();
+        } else {
+            // start invocation immediately if: the elapsedTime is greater than
+            // the interval, which means the last execution took longer than
+            // the interval itself.  otherwise, subtract the time the previous
+            // invocation took.
+            var timeToInvocation = (elapsedTime >= interval) ?
+                                    0 : (interval - elapsedTime);
+
+            self._nextHandlerId = setTimeout(function _nextInvocation() {
+                self._execute();
+            }, timeToInvocation);
+        }
     }
 };
-
 
 
 /**
@@ -202,6 +259,39 @@ Reissue.prototype._stop = function _stop() {
     self.emit('stop');
 };
 
+
+/**
+ * called when the interval function "times out", or in other words takes
+ * longer than then specified timeout interval. this blocks the next invocation
+ * of the interval function until user calls the callback on the timeout
+ * event.
+ * @private
+ * @method _onTimeout
+ * @return {undefined}
+ */
+Reissue.prototype._onTimeout = function _onTimeout() {
+
+    var self = this;
+
+    self._timeoutHandlerId.___reissue.fired = true;
+
+    function _internalOnTimeoutDone() {
+        self._timeoutHandlerId.___reissue.done = true;
+        self.emit('_timeoutComplete');
+    }
+
+    // if user is listening to timeout event, fire the event and block on its
+    // completion.
+    if (self.listenerCount('timeout') > 0) {
+        self.emit('timeout',  function onTimeoutHandlerComplete() {
+            _internalOnTimeoutDone();
+        });
+    }
+    // otherwise, we're done
+    else {
+        _internalOnTimeoutDone();
+    }
+};
 
 //------------------------------------------------------------------------------
 // public methods

--- a/test/index.js
+++ b/test/index.js
@@ -382,7 +382,7 @@ describe('Reissue module', function() {
         var timer = reissue.create({
             func: function(callback) {
                 out.push(i++);
-                return callback();
+                return setTimeout(callback, 400);
             },
             interval: 500
         });
@@ -397,7 +397,7 @@ describe('Reissue module', function() {
         // this should allow two invocations, then cancel the third.
         setTimeout(function() {
             timer.stop();
-        }, 1000);
+        }, 900);
     });
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -341,27 +341,6 @@ describe('Reissue module', function() {
     });
 
 
-    it('should start asynchronously after explicit 0 delay', function(done) {
-
-        var async = false;
-
-        var timer = reissue.create({
-            func: function(callback) {
-
-                // if async === false, this was called synchronously
-                assert.equal(async, true);
-                return done();
-                // no need to call reissue's callback here, as that will just
-                // invoke this function again and call done() which will fail
-                // the test.
-            },
-            interval: 100
-        });
-        timer.start(0);
-        async = true;
-    });
-
-
     it('should not execute first invocation if stop was called',
     function(done) {
 
@@ -459,10 +438,12 @@ describe('Reissue module', function() {
     });
 
 
-    it('should stop and timeout should never fire', function(done) {
+    it('should emit stop, first invocation and timeout should never fire',
+    function(done) {
 
         var timer = reissue.create({
             func: function(callback) {
+                assert.fail('should not get here!');
                 return setTimeout(callback, 500);
             },
             interval: 100,
@@ -474,9 +455,7 @@ describe('Reissue module', function() {
             return callback();
         });
 
-        timer.on('stop', function() {
-            return done();
-        });
+        timer.on('stop', done);
 
         timer.start();
         timer.stop();


### PR DESCRIPTION
Support `timeout` event. 

`timer.on('timeout', function(cb) { ... }`

Timeout event supplies a callback, which can allow you to block on the next invocation. You can also  return true on callback to throw away the results of the currently timed out invocation, and schedule another invocation immediately:

`timer.on('timeout', function(cb) {
    cb(true);
});`

Builds on top of `stop` event PR.