### PR TITLE
pass elapsed time to custom interval function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -182,8 +182,8 @@ Reissue.prototype._done = function _done(err) {
 
     // calculate delta interval
     const self = this;
-    const interval = self._interval();
     const elapsedTime = Date.now() - self._startTime;
+    const interval = self._interval(elapsedTime);
 
     // we're out of user supplied func now
     self._inUserFunc = false;

--- a/test/index.js
+++ b/test/index.js
@@ -530,4 +530,36 @@ describe('Reissue module', function() {
             timer.stop();
         }, 100);
     });
+
+
+    it('GH-4: should pass elapsed time to custom interval function',
+    function(done) {
+
+        let i = 1;
+
+        const timer = reissue.create({
+            func: function(callback) {
+                setTimeout(function() {
+                    i++;
+                    return callback();
+                }, i * 100);
+                return setTimeout(callback, 250);
+            },
+            interval: function(elapsedTime) {
+                assert.isNumber(elapsedTime);
+
+                if (i === 2) {
+                    assert.isAtLeast(elapsedTime, 100);
+                } else {
+                    assert.isAtLeast(elapsedTime, 200);
+                }
+                return 100;
+            }
+        });
+
+        setTimeout(function() {
+            timer.on('stop', done);
+            timer.stop();
+        }, 200);
+    });
 });


### PR DESCRIPTION
Fixes #4.

If the returned interval causes the setTimeout math to be less than 0, it will be treated as if it were 0 (or whatever the minimum is). 